### PR TITLE
add: UDP通信

### DIFF
--- a/Udp/ReceiveUdp.hpp
+++ b/Udp/ReceiveUdp.hpp
@@ -1,0 +1,48 @@
+// ----------------------------------------------------------------
+// ReceiveUdp.hpp
+//
+// UDP で LIDAR と YOLO のデータを受信するクラスの宣言
+//
+// Copyright (c) 2026 Maito Yasui
+// Released under the GNU GPL-3.0 License.
+// https://github.com/Nibosi0501/LiViMotion/blob/main/LICENSE
+// ----------------------------------------------------------------
+
+#pragma once
+
+#include <span>
+#include <vector>
+
+namespace rcv
+{
+    struct RecvBase
+    {
+    protected:
+        int sock;
+        RecvBase(const int port);
+        ~RecvBase();
+        ssize_t receiveLatest(std::vector<uint8_t> &outBuffer);
+    };
+
+    constexpr size_t LIDAR_HEADER_SIZE = sizeof(uint32_t);
+    constexpr size_t LIDAR_BODY_SIZE = 2 * sizeof(float); // x, y
+
+    struct RecvLidar : RecvBase
+    {
+        RecvLidar(const int port) : RecvBase(port) {}
+
+        bool receive(std::vector<std::pair<float, float>> &outPoints);
+        bool parse_packet(std::span<const uint8_t> packet, std::vector<std::pair<float, float>> &outPoints);
+    };
+
+    constexpr size_t YOLO_HEADER_SIZE = sizeof(uint32_t);
+    constexpr size_t YOLO_BODY_SIZE = 17 * 3 * sizeof(float);
+
+    struct RecvYolo : RecvBase
+    {
+        RecvYolo(const int port) : RecvBase(port) {}
+
+        bool receive(std::vector<std::vector<std::tuple<float, float, float>>> &outKeypoints_list);
+        bool parse_packet(std::span<const uint8_t> packet, std::vector<std::vector<std::tuple<float, float, float>>> &outKeypoints_list);
+    };
+}

--- a/Udp/SendUdp.hpp
+++ b/Udp/SendUdp.hpp
@@ -1,0 +1,33 @@
+// ----------------------------------------------------------------
+// SendUdp.hpp
+//
+// UDP で LIDAR のデータを送信するクラスの宣言
+//
+// Copyright (c) 2026 Maito Yasui
+// Released under the GNU GPL-3.0 License.
+// https://github.com/Nibosi0501/LiViMotion/blob/main/LICENSE
+// ----------------------------------------------------------------
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace snd
+{
+    struct SendBase
+    {
+    protected:
+        int sock;
+
+        SendBase(const int port, const std::string &ip);
+        ~SendBase();
+    };
+
+    struct SendLidar : SendBase
+    {
+        SendLidar(const int port, const std::string &ip) : SendBase(port, ip) {}
+
+        bool send(const std::vector<std::pair<float, float>> &points);
+    };
+}

--- a/Udp/receive_udp.cpp
+++ b/Udp/receive_udp.cpp
@@ -1,0 +1,181 @@
+// ----------------------------------------------------------------
+// receive_udp.cpp
+//
+// UDP で LIDAR と YOLO のデータを受信するクラスの実装
+//
+// Copyright (c) 2026 Maito Yasui
+// Released under the GNU GPL-3.0 License.
+// https://github.com/Nibosi0501/LiViMotion/blob/main/LICENSE
+// ----------------------------------------------------------------
+
+#include <iostream>
+#include <netinet/in.h>
+#include <unistd.h>
+#include <fcntl.h>
+
+#include "./ReceiveUdp.hpp"
+
+namespace rcv
+{
+    RecvBase::RecvBase(const int port)
+    {
+        sock = socket(AF_INET, SOCK_DGRAM, 0);
+        if (sock < 0)
+        {
+            std::cerr << "socket() failed\n";
+            std::exit(1);
+        }
+
+        sockaddr_in addr{};
+        addr.sin_family = AF_INET;
+        addr.sin_port = htons(port);
+        addr.sin_addr.s_addr = INADDR_ANY;
+
+        if (bind(sock, reinterpret_cast<sockaddr *>(&addr), sizeof(addr)) < 0)
+        {
+            std::cerr << "bind() failed\n";
+            close(sock);
+            std::exit(1);
+        }
+
+        int flags = fcntl(sock, F_GETFL, 0);
+        if (flags < 0)
+        {
+            std::cerr << "fcntl F_GETFL failed\n";
+            close(sock);
+            std::exit(1);
+        }
+        if (fcntl(sock, F_SETFL, flags | O_NONBLOCK) < 0)
+        {
+            std::cerr << "fcntl F_SETFL or O_NONBLOCK failed\n";
+            close(sock);
+            std::exit(1);
+        }
+    }
+
+    RecvBase::~RecvBase()
+    {
+        close(sock);
+    }
+
+    ssize_t RecvBase::receiveLatest(std::vector<uint8_t> &outBuffer)
+    {
+        ssize_t last_n = -1;
+        while (true)
+        {
+            ssize_t n = recvfrom(sock, outBuffer.data(), outBuffer.size(), 0, nullptr, nullptr);
+            if (n <= 0)
+            {
+                break;
+            }
+            last_n = n;
+        }
+        return last_n;
+    }
+
+    bool RecvLidar::receive(std::vector<std::pair<float, float>> &outPoints)
+    {
+        std::vector<uint8_t> buf(65535);
+        ssize_t last_n = receiveLatest(buf);
+        if (last_n > 0)
+        {
+            std::span<const uint8_t> packet(buf.data(), last_n);
+            return parse_packet(packet, outPoints);
+        }
+        return false;
+    }
+
+    bool RecvLidar::parse_packet(std::span<const uint8_t> packet, std::vector<std::pair<float, float>> &outPoints)
+    {
+        if (packet.size() < LIDAR_HEADER_SIZE)
+        {
+            std::cerr << "LIDAR から受信したパケットのヘッダーサイズが不正です" << std::endl;
+            return false;
+        }
+
+        int32_t num_persons;
+        std::memcpy(&num_persons, packet.data(), sizeof(int32_t));
+        if (num_persons < 0)
+        {
+            std::cerr << "LIDAR から受信したパケットの人数が不正です: " << num_persons << std::endl;
+            return false;
+        }
+
+        size_t expected = LIDAR_HEADER_SIZE + num_persons * LIDAR_BODY_SIZE;
+        if (packet.size() < expected)
+        {
+            std::cerr << "LIDAR から受信したパケットのサイズが不正です" << std::endl;
+            return false;
+        }
+
+        std::span<const uint8_t> body = packet.subspan(LIDAR_HEADER_SIZE);
+
+        outPoints.clear();
+        // 事前に必要なサイズを確保しておく
+        outPoints.reserve(num_persons); // 後にemplace_back するので resize ではなく reserve を使う
+
+        for (int i = 0; i < num_persons; i++)
+        {
+            float vals[2]; // x, y
+            std::memcpy(vals, body.data(), sizeof(vals));
+            outPoints.emplace_back(vals[0], vals[1]);
+            body = body.subspan(sizeof(vals));
+        }
+        return true;
+    }
+
+    bool RecvYolo::receive(std::vector<std::vector<std::tuple<float, float, float>>> &outKeypoints_list)
+    {
+        std::vector<uint8_t> buf(65535);
+        ssize_t last_n = receiveLatest(buf);
+        if (last_n > 0)
+        {
+            std::span<const uint8_t> packet(buf.data(), last_n);
+            return parse_packet(packet, outKeypoints_list);
+        }
+        return false;
+    }
+
+    bool RecvYolo::parse_packet(std::span<const uint8_t> packet, std::vector<std::vector<std::tuple<float, float, float>>> &outKeypoints_list)
+    {
+        if (packet.size() < YOLO_HEADER_SIZE)
+        {
+            std::cerr << "YOLO から受信したパケットのヘッダーサイズが不正です" << std::endl;
+            return false;
+        }
+
+        int32_t num_persons;
+        std::memcpy(&num_persons, packet.data(), sizeof(int32_t));
+        if (num_persons < 0)
+        {
+            std::cerr << "YOLO から受信したパケットの人数が不正です: " << num_persons << std::endl;
+            return false;
+        }
+
+        size_t expected = YOLO_HEADER_SIZE + num_persons * YOLO_BODY_SIZE;
+        if (packet.size() < expected)
+        {
+            std::cerr << "YOLO から受信したパケットのサイズが不正です" << std::endl;
+            return false;
+        }
+
+        // subspan でヘッダーをスキップしてボディだけのビューを作成
+        std::span<const uint8_t> body = packet.subspan(YOLO_HEADER_SIZE);
+
+        outKeypoints_list.clear();
+        // 事前に必要なサイズを確保しておく
+        outKeypoints_list.resize(num_persons); // 後に at(i).emplace_back するので reserve ではなく resize を使う
+
+        for (int i = 0; i < num_persons; i++)
+        {
+            for (int j = 0; j < 17; j++)
+            {
+                float vals[3]; // x, y, conf
+                std::memcpy(vals, body.data(), sizeof(vals));
+                outKeypoints_list.at(i).emplace_back(vals[0], vals[1], vals[2]);
+                body = body.subspan(sizeof(vals)); // 次のポイントへ移動
+            }
+        }
+        return true;
+    }
+}

--- a/Udp/send_udp.cpp
+++ b/Udp/send_udp.cpp
@@ -1,0 +1,95 @@
+// ----------------------------------------------------------------
+// send_udp.cpp
+//
+// UDP で LIDAR のデータを送信するクラスの実装
+//
+// Copyright (c) 2026 Maito Yasui
+// Released under the GNU GPL-3.0 License.
+// https://github.com/Nibosi0501/LiViMotion/blob/main/LICENSE
+// ----------------------------------------------------------------
+
+#include <arpa/inet.h>
+#include <fcntl.h>
+#include <iostream>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include "./SendUdp.hpp"
+
+namespace snd
+{
+    SendBase::SendBase(const int port, const std::string &ip)
+    {
+        sock = socket(AF_INET, SOCK_DGRAM, 0);
+        if (sock < 0)
+        {
+            std::cerr << "socket() failed\n";
+            std::exit(1);
+        }
+
+        sockaddr_in addr{};
+        addr.sin_family = AF_INET;
+        addr.sin_port = htons(port);
+        addr.sin_addr.s_addr = inet_addr(ip.c_str());
+
+        int flags = fcntl(sock, F_GETFL, 0);
+        if (flags < 0)
+        {
+            std::cerr << "fcntl F_GETFL failed\n";
+            close(sock);
+            std::exit(1);
+        }
+        if (fcntl(sock, F_SETFL, flags | O_NONBLOCK) < 0)
+        {
+            std::cerr << "fcntl F_SETFL or O_NONBLOCK failed\n";
+            close(sock);
+            std::exit(1);
+        }
+
+        if (connect(sock, reinterpret_cast<sockaddr *>(&addr), sizeof(addr)) < 0)
+        {
+            std::cerr << "connect() failed\n";
+            close(sock);
+            std::exit(1);
+        }
+    }
+    SendBase::~SendBase()
+    {
+        close(sock);
+    }
+
+    bool SendLidar::send(const std::vector<std::pair<float, float>> &points)
+    {
+        const int32_t num_points = static_cast<int32_t>(points.size());
+        if (num_points < 0) // num_points == 0は、検出なしを意味するため、送信する
+        {
+            return false; // 送信するポイントがない場合は何もしない
+        }
+        const std::size_t payload_size = num_points * sizeof(std::pair<float, float>);
+        const std::size_t totalSize = sizeof(num_points) + payload_size;
+
+        std::vector<uint8_t> buf(totalSize);
+        std::memcpy(buf.data(), &num_points, sizeof(num_points));
+        std::memcpy(buf.data() + sizeof(num_points), points.data(), payload_size);
+
+        // SendLidar::send() と ::send()は別物
+        // ::send() は<sys.socket.h>の関数
+        const ssize_t sent = ::send(sock, buf.data(), totalSize, 0);
+        if (sent < 0)
+        {
+            if (errno == EAGAIN || errno == EWOULDBLOCK)
+            {
+                // ソケットが一時的に送信できない場合は無視して次回に期待
+                return false;
+            }
+            else
+            {
+                // その他のエラーはログに出力
+                std::cerr << "send() failed: " << strerror(errno) << "\n";
+                return false;
+            }
+        }
+        return true;
+    }
+}


### PR DESCRIPTION
## 概要
LiDAR・YOLO からの UDP データを送受信するクラス群を新規追加した。

## 追加内容

### 送信側 (`SendUdp`)
- `SendBase` : ソケット生成・`connect`・非ブロッキング設定・デストラクタを担当する基底クラス
- `SendLidar` : LiDAR の点群データ `(x, y)` を UDP で送信するクラス

### 受信側 (`ReceiveUdp`)
- `RecvBase` : ソケット生成・`bind`・非ブロッキング設定・最新パケット取得 (`receiveLatest()`) を担当する基底クラス
- `RecvLidar` : LiDAR の点群データ `(x, y)` を受信・パースするクラス
- `RecvYolo` : YOLO のキーポイントデータ `(x, y, conf) × 17点` を受信・パースするクラス

## プロトコル仕様

| 種別 | ヘッダー | ボディ |
|---|---|---|
| LiDAR | 人数 (int32) | `(x, y)` × N人 (float32×2) |
| YOLO | 人数 (int32) | `(x, y, conf)` × 17点 × N人 (float32×3) |