### PR TITLE
add: Camera Calibration

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,0 +1,16 @@
+{
+    "configurations": [
+        {
+            "name": "Mac",
+            "includePath": [
+                "${workspaceFolder}/**",
+                "/opt/homebrew/Cellar/opencv/4.11.0_1/include/opencv4"
+            ],
+            "defines": [],
+            "compilerPath": "/usr/bin/clang",
+            "cStandard": "c17",
+            "intelliSenseMode": "macos-clang-arm64"
+        }
+    ],
+    "version": 4
+}

--- a/Calibration/Calibration.hpp
+++ b/Calibration/Calibration.hpp
@@ -1,0 +1,42 @@
+// ----------------------------------------------------------------
+// Calibration.hpp
+//
+// カメラキャリブレーションのためのクラス定義
+//
+// Copyright (c) 2026 Maito Yasui
+// Released under the GNU GPL-3.0 License.
+// https://github.com/Nibosi0501/LiViMotion/blob/main/LICENSE
+// ----------------------------------------------------------------
+
+#pragma once
+
+#include <opencv2/opencv.hpp>
+
+namespace clb
+{
+    struct Quad
+    {
+        cv::Point2f topLeft;
+        cv::Point2f topRight;
+        cv::Point2f bottomLeft;
+        cv::Point2f bottomRight;
+    };
+
+    struct Calibration
+    {
+        std::vector<std::vector<Quad>> calibrationQuads;
+        std::vector<std::vector<Quad>> transformQuads;
+        int cols;
+        int rows;
+        int windowWidth;
+        int windowHeight;
+        std::string attribute;
+        Calibration(const std::string &filename, const int _cols, const int _rows, const int _windowWidth, const int _windowHeight, const std::string &_attribute);
+
+        bool isPointInQuad(const cv::Point2f &targetPoint, const Quad &quad) const;
+        bool transformPoint(const cv::Point2f &targetPoint, cv::Point2f &outPoint) const;
+
+        // 確認描画用の関数
+        void transformImage(const cv::Mat &inputImage, cv::Mat &outImage) const;
+    };
+}

--- a/Calibration/calibration.cpp
+++ b/Calibration/calibration.cpp
@@ -1,0 +1,174 @@
+// ----------------------------------------------------------------
+// calibration.cpp
+//
+// カメラキャリブレーションのためのクラス実装
+//
+// Copyright (c) 2026 Maito Yasui
+// Released under the GNU GPL-3.0 License.
+// https://github.com/Nibosi0501/LiViMotion/blob/main/LICENSE
+// ----------------------------------------------------------------
+
+#include <fstream>
+#include <iostream>
+
+#include "./Calibration.hpp"
+
+namespace clb
+{
+    Calibration::Calibration(const std::string &filename, const int _cols, const int _rows, const int _windowWidth, const int _windowHeight, const std::string &_attribute)
+        : cols(_cols), rows(_rows), windowWidth(_windowWidth), windowHeight(_windowHeight), attribute(_attribute)
+    {
+        calibrationQuads.resize(rows - 1);
+        transformQuads.resize(rows - 1);
+        for (int i = 0; i < rows - 1; i++)
+        {
+            calibrationQuads.at(i).resize(cols - 1);
+            transformQuads.at(i).resize(cols - 1);
+        }
+
+        std::ifstream file(filename);
+        if (!file.is_open())
+        {
+            std::cerr << "キャリブレーションファイルが開けません: " << filename << std::endl;
+            std::cerr << "キャリブレーションファイルのパスは、一連のプログラムを実行するmain()関数のあるプログラムがあるディレクトリからの相対パスである必要があります。" << std::endl;
+            std::cerr << "main()関数がないプログラムでclb::Calibration calib()する際にも、指定するファイルのパスは、main()関数があるプログラムからの相対パスである必要があります。" << std::endl;
+            std::cerr << "ただし、#include の際には、Calibration.hppをincludeするプログラムからの相対パスで指定してください。" << std::endl;
+            std::cerr << "また、コンパイルコマンドに指定するcalibration.cppのパスは、main()関数があるプログラムからの相対パスで指定してください。" << std::endl;
+            return;
+        }
+
+        std::vector<std::vector<cv::Point2f>> gridPoints(rows, std::vector<cv::Point2f>(cols));
+        for (int row = 0; row < rows; row++)
+        {
+            for (int col = 0; col < cols; col++)
+            {
+                file >> gridPoints[row][col].x >> gridPoints[row][col].y;
+            }
+        }
+        // グリッド点から四角形を構成する
+        for (int row = 0; row < rows - 1; row++)
+        {
+            for (int col = 0; col < cols - 1; col++)
+            {
+                calibrationQuads[row][col].topLeft = gridPoints[row][col];
+                calibrationQuads[row][col].topRight = gridPoints[row][col + 1];
+                calibrationQuads[row][col].bottomRight = gridPoints[row + 1][col + 1];
+                calibrationQuads[row][col].bottomLeft = gridPoints[row + 1][col];
+            }
+        }
+
+        // キャリブレーション後の四角形座標を生成
+        Quad transformQuad;
+        for (int row = 0; row < rows - 1; row++)
+        {
+            for (int col = 0; col < cols - 1; col++)
+            {
+                float x0 = (static_cast<float>(windowWidth) / (cols - 1)) * col;
+                float y0 = (static_cast<float>(windowHeight) / (rows - 1)) * row;
+                float x1 = (static_cast<float>(windowWidth) / (cols - 1)) * (col + 1);
+                float y1 = (static_cast<float>(windowHeight) / (rows - 1)) * row;
+                float x2 = (static_cast<float>(windowWidth) / (cols - 1)) * (col + 1);
+                float y2 = (static_cast<float>(windowHeight) / (rows - 1)) * (row + 1);
+                float x3 = (static_cast<float>(windowWidth) / (cols - 1)) * col;
+                float y3 = (static_cast<float>(windowHeight) / (rows - 1)) * (row + 1);
+
+                transformQuad.topLeft = cv::Point2f(x0, y0);
+                transformQuad.topRight = cv::Point2f(x1, y1);
+                transformQuad.bottomRight = cv::Point2f(x2, y2);
+                transformQuad.bottomLeft = cv::Point2f(x3, y3);
+                transformQuads.at(row).at(col) = transformQuad;
+            }
+        }
+    }
+
+    bool Calibration::isPointInQuad(const cv::Point2f &targetPoint, const Quad &quad) const
+    {
+        std::vector<cv::Point2f> quadPoints = {
+            cv::Point2f(quad.topLeft),
+            cv::Point2f(quad.topRight),
+            cv::Point2f(quad.bottomRight),
+            cv::Point2f(quad.bottomLeft)};
+
+        int result = cv::pointPolygonTest(quadPoints, targetPoint, false);
+
+        if (result >= 0)
+        {
+            // 点は四角形内または境界線上にある
+            return true;
+        }
+        else
+        {
+            // 点は四角形外にある
+            return false;
+        }
+    }
+
+    bool Calibration::transformPoint(const cv::Point2f &targetPoint, cv::Point2f &outPoint) const
+    {
+        for (int row = 0; row < rows - 1; row++)
+        {
+            for (int col = 0; col < cols - 1; col++)
+            {
+                if (isPointInQuad(targetPoint, calibrationQuads.at(row).at(col)))
+                {
+                    std::vector<cv::Point2f> calibrationPoints = {
+                        cv::Point2f(calibrationQuads.at(row).at(col).topLeft),
+                        cv::Point2f(calibrationQuads.at(row).at(col).topRight),
+                        cv::Point2f(calibrationQuads.at(row).at(col).bottomRight),
+                        cv::Point2f(calibrationQuads.at(row).at(col).bottomLeft)};
+                    std::vector<cv::Point2f> transformPoints = {
+                        cv::Point2f(transformQuads.at(row).at(col).topLeft),
+                        cv::Point2f(transformQuads.at(row).at(col).topRight),
+                        cv::Point2f(transformQuads.at(row).at(col).bottomRight),
+                        cv::Point2f(transformQuads.at(row).at(col).bottomLeft)};
+
+                    cv::Mat Homography = cv::getPerspectiveTransform(calibrationPoints, transformPoints);
+
+                    std::vector<cv::Point2f> calibrationPointVec(1);
+                    calibrationPointVec.at(0) = targetPoint;
+                    std::vector<cv::Point2f> transformPointVec(1);
+                    cv::perspectiveTransform(calibrationPointVec, transformPointVec, Homography);
+                    outPoint = transformPointVec.at(0);
+                    return true;
+                }
+            }
+        }
+        return false; // どの四角形にも属さない場合は変換できない
+    }
+
+    void Calibration::transformImage(const cv::Mat &inputImage, cv::Mat &outImage) const
+    {
+        for (int row = 0; row < rows - 1; row++)
+        {
+            for (int col = 0; col < cols - 1; col++)
+            {
+                std::vector<cv::Point2f> calibrationPoints = {
+                    cv::Point2f(calibrationQuads.at(row).at(col).topLeft),
+                    cv::Point2f(calibrationQuads.at(row).at(col).topRight),
+                    cv::Point2f(calibrationQuads.at(row).at(col).bottomRight),
+                    cv::Point2f(calibrationQuads.at(row).at(col).bottomLeft)};
+                std::vector<cv::Point2f> transformPoints = {
+                    cv::Point2f(transformQuads.at(row).at(col).topLeft),
+                    cv::Point2f(transformQuads.at(row).at(col).topRight),
+                    cv::Point2f(transformQuads.at(row).at(col).bottomRight),
+                    cv::Point2f(transformQuads.at(row).at(col).bottomLeft)};
+
+                cv::Mat Homography = cv::getPerspectiveTransform(calibrationPoints, transformPoints);
+                cv::Mat warpedImage;
+                cv::warpPerspective(inputImage, warpedImage, Homography, outImage.size(), cv::INTER_LINEAR, cv::BORDER_CONSTANT);
+
+                // マスクを作成して重ね合わせ
+                cv::Mat mask = cv::Mat::zeros(outImage.size(), CV_8UC1);
+                std::vector<std::vector<cv::Point>> fillContAll;
+                std::vector<cv::Point> fillCont;
+                fillCont.push_back(transformPoints[0]);
+                fillCont.push_back(transformPoints[1]);
+                fillCont.push_back(transformPoints[2]);
+                fillCont.push_back(transformPoints[3]);
+                fillContAll.push_back(fillCont);
+                cv::fillPoly(mask, fillContAll, cv::Scalar(255));
+                warpedImage.copyTo(outImage, mask);
+            }
+        }
+    }
+}

--- a/Calibration/create_calibration_600x600.cpp
+++ b/Calibration/create_calibration_600x600.cpp
@@ -1,0 +1,324 @@
+// ----------------------------------------------------------------
+// create_calibration_600x600.cpp
+//
+// カメラキャリブレーション用のポイントを生成するプログラム.
+// このプログラムは、カメラからの映像を表示し、ユーザーがグリッド点をクリックしてキャリブレーションポイントを指定できるようにします.
+// 指定されたポイントは、"front_calibration600x600.txt" または "back_calibration600x600.txt" というテキストファイルに保存されます。
+// なお、本プログラムは、6m x 6m の床面映像を想定. それ以外のサイズの映像を使用する場合は、各種パラメータを適宜調整してください.
+//
+// Copyright (c) 2026 Maito Yasui
+// Released under the GNU GPL-3.0 License.
+// https://github.com/Nibosi0501/LiViMotion/blob/main/LICENSE
+// ----------------------------------------------------------------
+
+/* コンパイルコマンド例 (macOS):
+g++ -O3 -framework OpenGL -framework GLUT -Wno-deprecated `pkg-config --cflags --libs opencv4` -mmacosx-version-min=13.0 -std=c++17 create_calibration2.cpp
+*/
+
+#include <opencv2/opencv.hpp>
+#include <GLUT/glut.h>
+
+#include <iostream>
+#include <fstream>
+
+constexpr int CAMERA_DEVICE = 0;
+std::string FILE_PREFIX = "front_";
+// std::string FILE_PREFIX = "back_";
+
+void initGL();
+void display();
+void timer(int value);
+void reshape(int w, int h);
+void keyboard(unsigned char key, int x, int y);
+
+int winID[1];
+
+cv::VideoCapture capture;
+cv::Mat calibrationImage;
+std::vector<cv::Point2d> corners;
+std::vector<cv::Point2d> calibrationCorners;
+
+// カメラの画角調節中かどうかのフラグ
+bool adjustingFOV = true;
+
+void calibrateCamera();
+void onMouse(int event, int x, int y, int flags, void *userdata);
+
+bool saveCalibrationPoint(const std::string &filename);
+
+int main(int argc, char *argv[])
+{
+    glutInit(&argc, argv);
+
+    // 初期設定
+    initGL();
+
+    capture.open(CAMERA_DEVICE);
+    if (!capture.isOpened())
+    {
+        std::cerr << "カメラが開けません。" << std::endl;
+        return -1;
+    }
+
+    glutMainLoop();
+
+    return 0;
+}
+
+void initGL()
+{
+    glutInitDisplayMode(GLUT_RGBA | GLUT_DEPTH | GLUT_DOUBLE);
+    glutInitWindowSize(800, 500);
+    winID[0] = glutCreateWindow("CG");
+
+    glutDisplayFunc(display);
+    glutReshapeFunc(reshape);
+    glutKeyboardFunc(keyboard);
+    glutTimerFunc(33, timer, 0);
+
+    for (int i = 0; i < 1; i++)
+    {
+        glutSetWindow(winID[i]);
+
+        glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
+        glEnable(GL_DEPTH_TEST);
+        glEnable(GL_BLEND);
+        glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+        glEnable(GL_ALPHA_TEST);
+        glAlphaFunc(GL_GREATER, 0.01);
+    }
+}
+
+void display()
+{
+    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+    glLoadIdentity();
+
+    for (int row = 0; row < 7; row++)
+    {
+        for (int col = 0; col < 7; col++)
+        {
+            glPushMatrix();
+            glColor3f(1.0f, 1.0f, 0.0f);
+            glTranslated(-300.0 + 100.0 * row, 100.0 * col, 2.0);
+            glScaled(10.0, 10.0, 0.0);
+            glutSolidSphere(1.0, 36, 18);
+            glPopMatrix();
+        }
+    }
+
+    glPushMatrix();
+    glColor3f(1.0f, 0.0f, 0.0f);
+    glTranslated(0.0, 300.0, 2.0);
+    glScaled(10.0, 10.0, 0.0);
+    glutSolidSphere(1.0, 36, 18);
+    glPopMatrix();
+
+    glutSwapBuffers();
+}
+
+void reshape(int w, int h)
+{
+    glViewport(0, 0, w, h);
+    glMatrixMode(GL_PROJECTION);
+    glLoadIdentity();
+    glOrtho(546.0, -546.0, 0.0, 691.0, -3.0, 3.0);
+    glMatrixMode(GL_MODELVIEW);
+}
+
+void timer(int value)
+{
+    glutSetWindow(winID[0]);
+    glutTimerFunc(33, timer, 0);
+    glutPostRedisplay();
+
+    if (adjustingFOV)
+    {
+        capture >> calibrationImage;
+        if (calibrationImage.empty())
+        {
+            std::cerr << "カメラから画像が取得できません。" << std::endl;
+            std::abort();
+        }
+    }
+    else
+    {
+        calibrateCamera();
+    }
+
+    cv::imshow("Input Image", calibrationImage);
+}
+
+void calibrateCamera()
+{
+    cv::imwrite("calibration_600x600.png", calibrationImage);
+
+    cv::Mat grayImage;
+    cv::cvtColor(calibrationImage, grayImage, cv::COLOR_BGR2GRAY);
+    cv::Mat binImage;
+    cv::threshold(grayImage, binImage, 128, 255, cv::THRESH_BINARY | cv::THRESH_OTSU);
+
+    std::vector<std::vector<cv::Point>> counters;
+    cv::findContours(binImage, counters, cv::RETR_EXTERNAL, cv::CHAIN_APPROX_SIMPLE);
+
+    corners.clear();
+    for (int i = 0; i < counters.size(); i++)
+    {
+        double area = cv::contourArea(counters.at(i));
+        if (area < 0)
+        {
+            continue;
+        }
+
+        cv::Moments mu = cv::moments(counters.at(i));
+        if (mu.m00 == 0)
+        {
+            continue;
+        }
+        corners.emplace_back(mu.m10 / mu.m00, mu.m01 / mu.m00);
+        cv::circle(calibrationImage, corners.at(corners.size() - 1), 5, cv::Scalar(0, 255, 0), -1);
+    }
+
+    cv::imshow("Input Image", calibrationImage);
+    cv::setMouseCallback("Input Image", onMouse, nullptr);
+
+    std::cout << "画像上をクリックしてポイントを指定してください. 指定後に任意のキーを押して下さい." << std::endl;
+    cv::waitKey(0);
+
+    if (!saveCalibrationPoint(FILE_PREFIX + "calibration600x600.txt"))
+    {
+        std::cerr << "キャリブレーションポイントの保存に失敗しました。" << std::endl;
+        std::abort();
+    }
+
+    std::cout << "キャリブレーション完了。" << std::endl;
+    std::exit(0);
+}
+
+bool saveCalibrationPoint(const std::string &filename)
+{
+    std::ofstream file(filename);
+    if (!file.is_open())
+    {
+        std::cerr << "ファイルを開けません: " << filename << std::endl;
+        return false;
+    }
+
+    for (const auto &point : calibrationCorners)
+    {
+        file << point.x << " " << point.y << "\n";
+    }
+    file.close();
+    std::cout << "ポイントを保存しました: " << filename << std::endl;
+
+    if (calibrationCorners.size() != 49)
+    {
+        std::cerr << "警告: キャリブレーションポイントが49個ではありません。保存されたポイント数: " << calibrationCorners.size() << std::endl;
+    }
+
+    return true;
+}
+
+void onMouse(int event, int x, int y, int flags, void *userdata)
+{
+    if (event == cv::EVENT_LBUTTONDOWN || event == cv::EVENT_RBUTTONDOWN)
+    {
+        if (calibrationCorners.size() >= 49)
+        {
+            std::cout << "これ以上点を選択できません。" << std::endl;
+            return;
+        }
+    }
+
+    cv::Point2d addPoint(-1.0, -1.0);
+    if (event == cv::EVENT_LBUTTONDOWN)
+    {
+        double minDist = std::numeric_limits<double>::max();
+        int closestIndex = -1;
+        for (int i = 0; i < corners.size(); i++)
+        {
+            double dist = cv::norm(corners.at(i) - cv::Point2d(x, y));
+            if (dist < minDist)
+            {
+                minDist = dist;
+                closestIndex = i;
+            }
+        }
+        if (closestIndex == -1)
+        {
+            std::cerr << "点が見つかりませんでした。" << std::endl;
+            return;
+        }
+        addPoint = corners.at(closestIndex);
+    }
+    else if (event == cv::EVENT_RBUTTONDOWN)
+    {
+        addPoint = cv::Point2d(x, y);
+    }
+
+    if (addPoint == cv::Point2d(-1.0, -1.0))
+    {
+        return;
+    }
+
+    bool alreadySelected = false;
+    for (const auto &pt : calibrationCorners)
+    {
+        if (pt == addPoint)
+        {
+            alreadySelected = true;
+            break;
+        }
+    }
+    if (alreadySelected)
+    {
+        std::cout << "この点は既に選択されています。" << std::endl;
+        return;
+    }
+
+    calibrationCorners.emplace_back(addPoint);
+    std::cout << "キャリブレーション用コーナー追加: " << addPoint << std::endl;
+
+    // 追加したコーナーを表示
+    if (event == cv::EVENT_LBUTTONDOWN)
+    {
+        cv::circle(calibrationImage, addPoint, 10, cv::Scalar(0, 0, 255), 2);
+    }
+    else if (event == cv::EVENT_RBUTTONDOWN)
+    {
+        cv::circle(calibrationImage, addPoint, 10, cv::Scalar(255, 0, 0), 2);
+    }
+
+    cv::Mat annotationImage = calibrationImage.clone();
+    cv::putText(annotationImage, "Corners: " + std::to_string(calibrationCorners.size()) + "/" + std::to_string(49),
+                cv::Point(10, 30), cv::FONT_HERSHEY_SIMPLEX, 1.0,
+                cv::Scalar(255, 255, 255), 2);
+
+    cv::imshow("Input Image", annotationImage);
+}
+
+void keyboard(unsigned char key, int x, int y)
+{
+    switch (key)
+    {
+    case 27:
+    case 'q':
+    case 'Q':
+        exit(0);
+    case 'f':
+    case 'F':
+        glutFullScreen();
+        break;
+    case 'c':
+    case 'C':
+        imwrite("calibration_600x600.png", calibrationImage);
+        break;
+
+    case ' ':
+        adjustingFOV = false;
+        break;
+
+    default:
+        break;
+    }
+}


### PR DESCRIPTION
## 概要
カメラ映像と床面座標を対応付けるキャリブレーション機能を新規追加した。

## 追加内容

### キャリブレーションクラス (`Calibration.hpp` / `calibration.cpp`)
- `clb::Calibration` : キャリブレーションファイルを読み込み、座標変換を行うクラス
- `transformPoint()` : 入力点がどのグリッドセルに属するかを判定し、ホモグラフィ変換で対応するスクリーン座標に変換
- `transformImage()` : 確認用。入力画像をキャリブレーション結果に基づいて変換して描画

### キャリブレーションデータ作成ツール (`create_calibration_600x600.cpp`)
- GLUT で 7×7 のグリッド点をスクリーンに投影しながら、カメラ映像上の対応点をマウスでクリックして指定
- 左クリック: 輪郭重心から最近傍点を自動スナップ / 右クリック: 任意座標を直接指定
- 49点が揃うと `{prefix}_calibration600x600.txt` に座標を保存して終了

## キャリブレーションファイルのフォーマット
```
x0 y0
x1 y1
...
```
行×列のグリッド順に座標を記録したテキスト形式。