### PR TITLE
add: 2D LiDAR

### DIFF
--- a/LiDAR/main_600x600.cpp
+++ b/LiDAR/main_600x600.cpp
@@ -1,0 +1,32 @@
+// ----------------------------------------------------------------
+// main_600x600.cpp
+//
+// 二次元LiDARで 6m x 6m の範囲をスキャンし、人の足位置を検出、送信.
+// LiDARを使用するためのライブラリの権利関係により、LiDARのスキャン処理は記載していません。
+// LiDARのスキャン処理は、使用するLiDARのSDKやAPIに応じて実装してください。
+//
+// Copyright (c) 2026 Maito Yasui
+// Released under the GNU GPL-3.0 License.
+// https://github.com/Nibosi0501/LiViMotion/blob/main/LICENSE
+// ----------------------------------------------------------------
+
+// LiDARのスキャン結果を二値画像として取得
+// 膨張収縮処理、輪郭抽出、重心計算を行い、足位置を検出
+/* OpenGL座標系に変換(必要であれば)
+    float mapValue(const int x, const int in_min, const int in_max, const float out_min, const float out_max)
+    {
+        return static_cast<float>(x - in_min) * (out_max - out_min) / static_cast<float>(in_max - in_min) + out_min;
+    }
+*/
+
+/* UDPで送信
+    #include "../Udp/SendUdp.hpp"   // UDP送信クラスのヘッダファイル
+
+    snd::SendLidar sendLidar(12345, "127.0.0.1");   // ポート番号と送信先IPアドレスを指定してSendLidarクラスのインスタンスを作成
+
+    std::vector<std::pair<float, float>> points;    // 足位置の座標を格納するベクター
+
+    // 足位置の座標をpointsベクターに追加
+
+    sendLidar.send(points); // 足位置の座標をUDPで送信
+*/


### PR DESCRIPTION
## 概要
URG LiDAR（UST-20LX-H01）から取得した距離データを处理し、人物重心座標を UDP で送信するメインプログラムを新規追加した。

## 追加内容
- URG から距離データを取得し、GLUT で点群を描画
- レンダリング結果を OpenCV で読み取り、拡張・二値化処理により人物領域を検出
- 輪郭重心をスクリーン座標から世界座標に変換（`gluUnProject`）し、`SendLidar` で UDP 送信
- スキャン範囲: 正面 180°、相対距離座標内に入った点のみを送信対象とする

## 処理フロー
1. URG から距離データを取得（180°スキャン、角度分解能 0.125°）
2. GLUT で各距離点をスプライト描画（距離に応じた円形サイズで表現）
3. `glReadPixels` でレンダリング結果を読み取り、二値化 + `dilate` で人物領域を抽出
4. `findContours` で輪郭検出、面穉50以上の領域の重心を算出
5. `gluUnProject` でスクリーン座標→世界座標に変換し、領域外の点をフィルタリング
6. `snd::SendLidar` で座標リストを UDP 送信 (`127.0.0.1:12345`)

## パラメータ
| 定数 | 値 | 内容 |
|---|---|---|
| `scanAngle` | 180° | スキャン角度範囲 |
| `scanAreaW / H` | 1024 / 691 | 表示ウィンドウサイズ |
| `frameRate` | 60 fps | 更新間隔 |
| `dilate` 回数 | 12 | 人物領域拡張幅 |
| 送信先 | `127.0.0.1:12345` | UDP 送信先 |