### PR TITLE
add: lidar

### DIFF
--- a/Experiment/600x600/Lidar/Lidar.hpp
+++ b/Experiment/600x600/Lidar/Lidar.hpp
@@ -1,0 +1,22 @@
+// ----------------------------------------------------------------
+// Lidar.hpp
+//
+// 2D LiDARのデータ構造とコンストラクタの宣言
+//
+// Copyright (c) 2026 Maito Yasui
+// Released under the GNU GPL-3.0 License.
+// https://github.com/Nibosi0501/LiViMotion/blob/main/LICENSE
+// ----------------------------------------------------------------
+
+#pragma once
+
+namespace lidar
+{
+    struct Lidar
+    {
+        float footX;
+        float footY;
+
+        Lidar(const float &_x, const float &_y);
+    };
+}

--- a/Experiment/600x600/Lidar/lidar.cpp
+++ b/Experiment/600x600/Lidar/lidar.cpp
@@ -1,0 +1,16 @@
+// ----------------------------------------------------------------
+// lidar.cpp
+//
+// 2D LiDARのデータ構造とコンストラクタの実装
+//
+// Copyright (c) 2026 Maito Yasui
+// Released under the GNU GPL-3.0 License.
+// https://github.com/Nibosi0501/LiViMotion/blob/main/LICENSE
+// ----------------------------------------------------------------
+
+#include "./Lidar.hpp"
+
+namespace lidar
+{
+    Lidar::Lidar(const float &_x, const float &_y) : footX(_x), footY(_y) {}
+}


### PR DESCRIPTION
## 概要
LiDAR から受信した点の足位置座標 `(x, y)` を保持するシンプルなデータクラスを新規追加した。

## 追加内容
- `lidar::Lidar` : `footX` / `footY` を持つ値型の構造体
- トラッカーや描画処理で LiDAR の点データを受け渡す際の型として使用する