### PR TITLE
add: Kalman Filter

### DIFF
--- a/Experiment/600x600/Kalman/Kalman.hpp
+++ b/Experiment/600x600/Kalman/Kalman.hpp
@@ -1,0 +1,31 @@
+// ----------------------------------------------------------------
+// Kalman.hpp
+//
+// カルマンフィルタのためのヘッダーファイル
+//
+// Copyright (c) 2026 Maito Yasui
+// Released under the GNU GPL-3.0 License.
+// https://github.com/Nibosi0501/LiViMotion/blob/main/LICENSE
+// ----------------------------------------------------------------
+
+#pragma once
+
+#include <opencv2/opencv.hpp>
+
+#include "../Yolo/Yolo.hpp"
+
+namespace kf
+{
+    struct KalmanYolo
+    {
+        cv::KalmanFilter kf;        // OpenCVのカルマンフィルタクラス
+        cv::Point2f predictedPoint; // 予測された位置
+
+        KalmanYolo(const yolo::Yolo &observedYolo);
+        void update(const yolo::Yolo &observedYolo); // 観測値を用いてカルマンフィルタを更新
+        void predict();                              // 観測なしの予測ステップ
+
+        // 将来の予測ステップ (numFrames フレーム先を予測)
+        void futurePredict(cv::Point2f &futurePredictPoint, const int numFrames) const;
+    };
+}

--- a/Experiment/600x600/Kalman/kalman.cpp
+++ b/Experiment/600x600/Kalman/kalman.cpp
@@ -1,0 +1,80 @@
+// ----------------------------------------------------------------
+// kalman.cpp
+//
+// カルマンフィルタの実装
+//
+// Copyright (c) 2026 Maito Yasui
+// Released under the GNU GPL-3.0 License.
+// https://github.com/Nibosi0501/LiViMotion/blob/main/LICENSE
+// ----------------------------------------------------------------
+
+#include "./Kalman.hpp"
+
+namespace kf
+{
+    KalmanYolo::KalmanYolo(const yolo::Yolo &observedYolo)
+    {
+        // カルマンフィルタの初期化
+        kf.init(4, 2, 0);
+
+        // 速度減衰モデル: alpha < 1.0 で静止時の復帰を速くする
+        // alpha が小さいほど速く止まるが、動きへの追従も落ちる
+        float alpha = 0.8f;
+
+        // 状態遷移行列
+        kf.transitionMatrix = (cv::Mat_<float>(4, 4) << 1, 0, 1, 0,
+                               0, 1, 0, 1,
+                               0, 0, alpha, 0,
+                               0, 0, 0, alpha);
+
+        // 観測行列
+        kf.measurementMatrix = (cv::Mat_<float>(2, 4) << 1, 0, 0, 0,
+                                0, 1, 0, 0);
+
+        // プロセスノイズ共分散行列
+        setIdentity(kf.processNoiseCov, cv::Scalar(1e-2));
+
+        // 観測ノイズ共分散行列
+        setIdentity(kf.measurementNoiseCov, cv::Scalar(1e-1));
+
+        // 事後誤差共分散行列
+        setIdentity(kf.errorCovPost, cv::Scalar(1));
+
+        // 初期状態
+        kf.statePost = (cv::Mat_<float>(4, 1) << observedYolo.footX, observedYolo.footY, 0, 0);
+
+        // 初期予測位置
+        predictedPoint = cv::Point2f(observedYolo.footX, observedYolo.footY);
+    }
+
+    // 観測値を用いてカルマンフィルタを更新
+    void KalmanYolo::update(const yolo::Yolo &observedYolo)
+    {
+        cv::Mat prediction = kf.predict();                                              // 予測ステップ
+        predictedPoint = cv::Point2f(prediction.at<float>(0), prediction.at<float>(1)); // 予測位置を更新
+
+        cv::Mat measurement = (cv::Mat_<float>(2, 1) << observedYolo.footX, observedYolo.footY); // 観測値を作成
+        kf.correct(measurement);                                                                 // 更新ステップ
+    }
+
+    // 観測なしの予測ステップ
+    void KalmanYolo::predict()
+    {
+        cv::Mat prediction = kf.predict();                                              // 予測ステップ
+        predictedPoint = cv::Point2f(prediction.at<float>(0), prediction.at<float>(1)); // 予測位置を更新
+    }
+
+    // 将来の予測ステップ (numFrames フレーム先を予測)
+    void KalmanYolo::futurePredict(cv::Point2f &futurePredictPoint, const int numFrames) const
+    {
+        cv::Mat futureState = kf.statePost.clone(); // 現在の状態をコピー
+        for (int i = 0; i < numFrames; i++)
+        {
+            // 予測ステップを繰り返す
+            futureState = kf.transitionMatrix * futureState;
+        }
+
+        // 予測された将来の位置を futurePredictPoint に格納
+        futurePredictPoint = cv::Point2f(futureState.at<float>(0), futureState.at<float>(1));
+    }
+}


### PR DESCRIPTION
## 概要
YOLO の足位置座標にカルマンフィルタを適用し、ノイズを包含む足位置のスムージングと将来位置予測を行うクラスを新規追加した。

## 追加内容
- `kf::KalmanYolo` : OpenCV の `cv::KalmanFilter` をラップしたクラス
- 状態: 位置 `(x, y)` + 速度 `(vx, vy)` の 4 次元、観測: 位置のみ 2 次元
- 速度減衰モデル（`alpha = 0.8`）で静止時に速やかに収束
- `update()`: 観測値ありの予測・更新ステップ
- `predict()`: 観測なしの予測ステップのみ（メッセージ欠落フレーム向け）
- `futurePredict()`: 現在の状態から N フレーム先の位置を予測

## モデル仕様
| 項目 | 内容 |
|---|---|
| 状態ベクトル | `[x, y, vx, vy]` (4次元) |
| 観測ベクトル | `[x, y]` (2次元) |
| 速度減衰係数 alpha | 0.8 |
| プロセスノイズ | 1e-2 |
| 観測ノイズ | 1e-1 |

## クラス・関数構成
| 関数 | 役割 |
|---|---|
| `KalmanYolo(observedYolo)` | 初期位置でフィルタを初期化 |
| `update(observedYolo)` | 観測値ありの予測・更新ステップ |
| `predict()` | 観測なしの予測ステップ（メッセージ欠落フレーム向け） |
| `futurePredict(point, N)` | 現在の `statePost` から N フレーム先の位置を計算 |