### PR TITLE
Tracker

### DIFF
--- a/Experiment/600x600/Tracker/Hungarian/Hungarian.hpp
+++ b/Experiment/600x600/Tracker/Hungarian/Hungarian.hpp
@@ -1,0 +1,46 @@
+///////////////////////////////////////////////////////////////////////////////
+// Hungarian.h: Header file for Class HungarianAlgorithm.
+//
+// This is a C++ wrapper with slight modification of a hungarian algorithm implementation by Markus Buehren.
+// The original implementation is a few mex-functions for use in MATLAB, found here:
+// http://www.mathworks.com/matlabcentral/fileexchange/6543-functions-for-the-rectangular-assignment-problem
+//
+// Both this code and the orignal code are published under the BSD license.
+// by Cong Ma, 2016
+//
+// Copyright (c) 2014, Markus Buehren
+// All rights reserved.
+//
+// Copyright (c) 2019 Delta Group, City Univeristy of Hong Kong
+// Copyright (c) 2019 Dr. Li Shuaicheng
+// Released under the MIT License. https://github.com/deepomicslab/SuperTAD/blob/master/LICENSE.md
+//
+// modified by Maito Yasui on 2026-04-02
+//
+// Copyright (c) 2026 Maito Yasui
+// This file incorporates code licensed under the BSD and MIT Licenses (see above).
+// Modifications and additions by Maito Yasui are released under the GNU GPL-3.0.
+// https://github.com/Nibosi0501/LiViMotion/blob/main/LICENSE
+
+#pragma once
+
+#include <iostream>
+#include <vector>
+#include <stdlib.h>
+#include <cfloat>
+#include <cmath>
+
+namespace Hungarian
+{
+    double Solve(std::vector<std::vector<double>> &DistMatrix, std::vector<int> &Assignment);
+    void assignmentoptimal(int *assignment, double *cost, double *distMatrixIn, int nOfRows, int nOfColumns);
+    void buildassignmentvector(int *assignment, bool *starMatrix, int nOfRows, int nOfColumns);
+    void computeassignmentcost(int *assignment, double *cost, double *distMatrix, int nOfRows);
+    void step2a(int *assignment, double *distMatrix, bool *starMatrix, bool *newStarMatrix, bool *primeMatrix, bool *coveredColumns, bool *coveredRows, int nOfRows, int nOfColumns, int minDim);
+    void step2b(int *assignment, double *distMatrix, bool *starMatrix, bool *newStarMatrix, bool *primeMatrix, bool *coveredColumns, bool *coveredRows, int nOfRows, int nOfColumns, int minDim);
+    void step3(int *assignment, double *distMatrix, bool *starMatrix, bool *newStarMatrix, bool *primeMatrix, bool *coveredColumns, bool *coveredRows, int nOfRows, int nOfColumns, int minDim);
+    void step4(int *assignment, double *distMatrix, bool *starMatrix, bool *newStarMatrix, bool *primeMatrix, bool *coveredColumns, bool *coveredRows, int nOfRows, int nOfColumns, int minDim, int row, int col);
+    void step5(int *assignment, double *distMatrix, bool *starMatrix, bool *newStarMatrix, bool *primeMatrix, bool *coveredColumns, bool *coveredRows, int nOfRows, int nOfColumns, int minDim);
+
+    bool isLink();
+}

--- a/Experiment/600x600/Tracker/Hungarian/hungarian.cpp
+++ b/Experiment/600x600/Tracker/Hungarian/hungarian.cpp
@@ -1,0 +1,411 @@
+///////////////////////////////////////////////////////////////////////////////
+// Hungarian.cpp: Implementation file for Class HungarianAlgorithm.
+//
+// This is a C++ wrapper with slight modification of a hungarian algorithm implementation by Markus Buehren.
+// The original implementation is a few mex-functions for use in MATLAB, found here:
+// http://www.mathworks.com/matlabcentral/fileexchange/6543-functions-for-the-rectangular-assignment-problem
+//
+// Both this code and the orignal code are published under the BSD license.
+// by Cong Ma, 2016
+//
+// Copyright (c) 2014, Markus Buehren
+// All rights reserved.
+//
+// modified by wang mengbo on 2020-07-30
+//
+// Copyright (c) 2019 Delta Group, City Univeristy of Hong Kong
+// Copyright (c) 2019 Dr. Li Shuaicheng
+// Released under the MIT License. https://github.com/deepomicslab/SuperTAD/blob/master/LICENSE.md
+//
+// modified by Maito Yasui on 2026-04-02
+//
+// Copyright (c) 2026 Maito Yasui
+// This file incorporates code licensed under the BSD and MIT Licenses (see above).
+// Modifications and additions by Maito Yasui are released under the GNU GPL-3.0.
+// https://github.com/Nibosi0501/LiViMotion/blob/main/LICENSE
+
+#include <iostream>
+#include <vector>
+#include <stdlib.h>
+#include <cfloat>
+#include <cmath>
+
+#include "./Hungarian.hpp"
+
+//********************************************************//
+// A single function wrapper for solving assignment problem.
+//********************************************************//
+double Hungarian::Solve(std::vector<std::vector<double>> &DistMatrix, std::vector<int> &Assignment)
+{
+    unsigned int nRows = DistMatrix.size();
+    unsigned int nCols = DistMatrix[0].size();
+
+    double *distMatrixIn = new double[nRows * nCols];
+    int *assignment = new int[nRows];
+    double cost = 0.0;
+
+    // Fill in the distMatrixIn. Mind the index is "i + nRows * j".
+    // Here the cost matrix of size MxN is defined as a double precision array of N*M elements.
+    // In the solving functions matrices are seen to be saved MATLAB-internally in row-order.
+    // (i.e. the matrix [1 2; 3 4] will be stored as a vector [1 3 2 4], NOT [1 2 3 4]).
+    for (unsigned int i = 0; i < nRows; i++)
+        for (unsigned int j = 0; j < nCols; j++)
+            distMatrixIn[i + nRows * j] = DistMatrix[i][j];
+
+    // call solving function
+    Hungarian::assignmentoptimal(assignment, &cost, distMatrixIn, nRows, nCols);
+
+    Assignment.clear();
+    for (unsigned int r = 0; r < nRows; r++)
+        Assignment.push_back(assignment[r]);
+
+    delete[] distMatrixIn;
+    delete[] assignment;
+    return cost;
+}
+
+//********************************************************//
+// Solve optimal solution for assignment problem using Munkres algorithm, also known as Hungarian Algorithm.
+//********************************************************//
+void Hungarian::assignmentoptimal(int *assignment, double *cost, double *distMatrixIn, int nOfRows, int nOfColumns)
+{
+    double *distMatrix, *distMatrixTemp, *distMatrixEnd, *columnEnd, value, minValue;
+    bool *coveredColumns, *coveredRows, *starMatrix, *newStarMatrix, *primeMatrix;
+    int nOfElements, minDim, row, col;
+
+    /* initialization */
+    *cost = 0;
+    for (row = 0; row < nOfRows; row++)
+        assignment[row] = -1;
+
+    /* generate working copy of distance Matrix */
+    /* check if all matrix elements are positive */
+    nOfElements = nOfRows * nOfColumns;
+    distMatrix = (double *)malloc(nOfElements * sizeof(double));
+    distMatrixEnd = distMatrix + nOfElements;
+
+    for (row = 0; row < nOfElements; row++)
+    {
+        value = distMatrixIn[row];
+        //		if (value < 0)
+        //			cerr << "All matrix elements have to be non-negative." << endl;
+        distMatrix[row] = value;
+    }
+
+    /* memory allocation */
+    coveredColumns = (bool *)calloc(nOfColumns, sizeof(bool));
+    coveredRows = (bool *)calloc(nOfRows, sizeof(bool));
+    starMatrix = (bool *)calloc(nOfElements, sizeof(bool));
+    primeMatrix = (bool *)calloc(nOfElements, sizeof(bool));
+    newStarMatrix = (bool *)calloc(nOfElements, sizeof(bool)); /* used in step4 */
+
+    /* preliminary steps */
+    if (nOfRows <= nOfColumns)
+    {
+        minDim = nOfRows;
+
+        for (row = 0; row < nOfRows; row++)
+        {
+            /* find the smallest element in the row */
+            distMatrixTemp = distMatrix + row;
+            minValue = *distMatrixTemp;
+            distMatrixTemp += nOfRows;
+            while (distMatrixTemp < distMatrixEnd)
+            {
+                value = *distMatrixTemp;
+                if (value < minValue)
+                    minValue = value;
+                distMatrixTemp += nOfRows;
+            }
+
+            /* subtract the smallest element from each element of the row */
+            distMatrixTemp = distMatrix + row;
+            while (distMatrixTemp < distMatrixEnd)
+            {
+                *distMatrixTemp -= minValue;
+                distMatrixTemp += nOfRows;
+            }
+        }
+
+        /* Steps 1 and 2a */
+        for (row = 0; row < nOfRows; row++)
+            for (col = 0; col < nOfColumns; col++)
+                if (fabs(distMatrix[row + nOfRows * col]) < DBL_EPSILON)
+                    if (!coveredColumns[col])
+                    {
+                        starMatrix[row + nOfRows * col] = true;
+                        coveredColumns[col] = true;
+                        break;
+                    }
+    }
+    else /* if(nOfRows > nOfColumns) */
+    {
+        minDim = nOfColumns;
+
+        for (col = 0; col < nOfColumns; col++)
+        {
+            /* find the smallest element in the column */
+            distMatrixTemp = distMatrix + nOfRows * col;
+            columnEnd = distMatrixTemp + nOfRows;
+
+            minValue = *distMatrixTemp++;
+            while (distMatrixTemp < columnEnd)
+            {
+                value = *distMatrixTemp++;
+                if (value < minValue)
+                    minValue = value;
+            }
+
+            /* subtract the smallest element from each element of the column */
+            distMatrixTemp = distMatrix + nOfRows * col;
+            while (distMatrixTemp < columnEnd)
+                *distMatrixTemp++ -= minValue;
+        }
+
+        /* Steps 1 and 2a */
+        for (col = 0; col < nOfColumns; col++)
+            for (row = 0; row < nOfRows; row++)
+                if (fabs(distMatrix[row + nOfRows * col]) < DBL_EPSILON)
+                    if (!coveredRows[row])
+                    {
+                        starMatrix[row + nOfRows * col] = true;
+                        coveredColumns[col] = true;
+                        coveredRows[row] = true;
+                        break;
+                    }
+        for (row = 0; row < nOfRows; row++)
+            coveredRows[row] = false;
+    }
+
+    /* move to step 2b */
+    Hungarian::step2b(assignment, distMatrix, starMatrix, newStarMatrix, primeMatrix, coveredColumns, coveredRows, nOfRows, nOfColumns, minDim);
+
+    /* compute cost and remove invalid assignments */
+    Hungarian::computeassignmentcost(assignment, cost, distMatrixIn, nOfRows);
+
+    /* free allocated memory */
+    free(distMatrix);
+    free(coveredColumns);
+    free(coveredRows);
+    free(starMatrix);
+    free(primeMatrix);
+    free(newStarMatrix);
+
+    return;
+}
+
+/********************************************************/
+void Hungarian::buildassignmentvector(int *assignment, bool *starMatrix, int nOfRows, int nOfColumns)
+{
+    int row, col;
+
+    for (row = 0; row < nOfRows; row++)
+        for (col = 0; col < nOfColumns; col++)
+            if (starMatrix[row + nOfRows * col])
+            {
+#ifdef ONE_INDEXING
+                assignment[row] = col + 1; /* MATLAB-Indexing */
+#else
+                assignment[row] = col;
+#endif
+                break;
+            }
+}
+
+/********************************************************/
+void Hungarian::computeassignmentcost(int *assignment, double *cost, double *distMatrix, int nOfRows)
+{
+    int row, col;
+
+    for (row = 0; row < nOfRows; row++)
+    {
+        col = assignment[row];
+        if (col >= 0)
+            *cost += distMatrix[row + nOfRows * col];
+    }
+}
+
+/********************************************************/
+void Hungarian::step2a(int *assignment, double *distMatrix, bool *starMatrix, bool *newStarMatrix, bool *primeMatrix, bool *coveredColumns, bool *coveredRows, int nOfRows, int nOfColumns, int minDim)
+{
+    bool *starMatrixTemp, *columnEnd;
+    int col;
+
+    /* cover every column containing a starred zero */
+    for (col = 0; col < nOfColumns; col++)
+    {
+        starMatrixTemp = starMatrix + nOfRows * col;
+        columnEnd = starMatrixTemp + nOfRows;
+        while (starMatrixTemp < columnEnd)
+        {
+            if (*starMatrixTemp++)
+            {
+                coveredColumns[col] = true;
+                break;
+            }
+        }
+    }
+
+    /* move to step 3 */
+    Hungarian::step2b(assignment, distMatrix, starMatrix, newStarMatrix, primeMatrix, coveredColumns, coveredRows, nOfRows, nOfColumns, minDim);
+}
+
+/********************************************************/
+void Hungarian::step2b(int *assignment, double *distMatrix, bool *starMatrix, bool *newStarMatrix, bool *primeMatrix, bool *coveredColumns, bool *coveredRows, int nOfRows, int nOfColumns, int minDim)
+{
+    int col, nOfCoveredColumns;
+
+    /* count covered columns */
+    nOfCoveredColumns = 0;
+    for (col = 0; col < nOfColumns; col++)
+        if (coveredColumns[col])
+            nOfCoveredColumns++;
+
+    if (nOfCoveredColumns == minDim)
+    {
+        /* algorithm finished */
+        Hungarian::buildassignmentvector(assignment, starMatrix, nOfRows, nOfColumns);
+    }
+    else
+    {
+        /* move to step 3 */
+        Hungarian::step3(assignment, distMatrix, starMatrix, newStarMatrix, primeMatrix, coveredColumns, coveredRows, nOfRows, nOfColumns, minDim);
+    }
+}
+
+/********************************************************/
+void Hungarian::step3(int *assignment, double *distMatrix, bool *starMatrix, bool *newStarMatrix, bool *primeMatrix, bool *coveredColumns, bool *coveredRows, int nOfRows, int nOfColumns, int minDim)
+{
+    bool zerosFound;
+    int row, col, starCol;
+
+    zerosFound = true;
+    while (zerosFound)
+    {
+        zerosFound = false;
+        for (col = 0; col < nOfColumns; col++)
+            if (!coveredColumns[col])
+                for (row = 0; row < nOfRows; row++)
+                    if ((!coveredRows[row]) && (fabs(distMatrix[row + nOfRows * col]) < DBL_EPSILON))
+                    {
+                        /* prime zero */
+                        primeMatrix[row + nOfRows * col] = true;
+
+                        /* find starred zero in current row */
+                        for (starCol = 0; starCol < nOfColumns; starCol++)
+                            if (starMatrix[row + nOfRows * starCol])
+                                break;
+
+                        if (starCol == nOfColumns) /* no starred zero found */
+                        {
+                            /* move to step 4 */
+                            Hungarian::step4(assignment, distMatrix, starMatrix, newStarMatrix, primeMatrix, coveredColumns, coveredRows, nOfRows, nOfColumns, minDim, row, col);
+                            return;
+                        }
+                        else
+                        {
+                            coveredRows[row] = true;
+                            coveredColumns[starCol] = false;
+                            zerosFound = true;
+                            break;
+                        }
+                    }
+    }
+
+    /* move to step 5 */
+    Hungarian::step5(assignment, distMatrix, starMatrix, newStarMatrix, primeMatrix, coveredColumns, coveredRows, nOfRows, nOfColumns, minDim);
+}
+
+/********************************************************/
+void Hungarian::step4(int *assignment, double *distMatrix, bool *starMatrix, bool *newStarMatrix, bool *primeMatrix, bool *coveredColumns, bool *coveredRows, int nOfRows, int nOfColumns, int minDim, int row, int col)
+{
+    int n, starRow, starCol, primeRow, primeCol;
+    int nOfElements = nOfRows * nOfColumns;
+
+    /* generate temporary copy of starMatrix */
+    for (n = 0; n < nOfElements; n++)
+        newStarMatrix[n] = starMatrix[n];
+
+    /* star current zero */
+    newStarMatrix[row + nOfRows * col] = true;
+
+    /* find starred zero in current column */
+    starCol = col;
+    for (starRow = 0; starRow < nOfRows; starRow++)
+        if (starMatrix[starRow + nOfRows * starCol])
+            break;
+
+    while (starRow < nOfRows)
+    {
+        /* unstar the starred zero */
+        newStarMatrix[starRow + nOfRows * starCol] = false;
+
+        /* find primed zero in current row */
+        primeRow = starRow;
+        for (primeCol = 0; primeCol < nOfColumns; primeCol++)
+            if (primeMatrix[primeRow + nOfRows * primeCol])
+                break;
+
+        /* star the primed zero */
+        newStarMatrix[primeRow + nOfRows * primeCol] = true;
+
+        /* find starred zero in current column */
+        starCol = primeCol;
+        for (starRow = 0; starRow < nOfRows; starRow++)
+            if (starMatrix[starRow + nOfRows * starCol])
+                break;
+    }
+
+    /* use temporary copy as new starMatrix */
+    /* delete all primes, uncover all rows */
+    for (n = 0; n < nOfElements; n++)
+    {
+        primeMatrix[n] = false;
+        starMatrix[n] = newStarMatrix[n];
+    }
+    for (n = 0; n < nOfRows; n++)
+        coveredRows[n] = false;
+
+    /* move to step 2a */
+    Hungarian::step2a(assignment, distMatrix, starMatrix, newStarMatrix, primeMatrix, coveredColumns, coveredRows, nOfRows, nOfColumns, minDim);
+}
+
+/********************************************************/
+void Hungarian::step5(int *assignment, double *distMatrix, bool *starMatrix, bool *newStarMatrix, bool *primeMatrix, bool *coveredColumns, bool *coveredRows, int nOfRows, int nOfColumns, int minDim)
+{
+    double h, value;
+    int row, col;
+
+    /* find smallest uncovered element h */
+    h = DBL_MAX;
+    for (row = 0; row < nOfRows; row++)
+        if (!coveredRows[row])
+            for (col = 0; col < nOfColumns; col++)
+                if (!coveredColumns[col])
+                {
+                    value = distMatrix[row + nOfRows * col];
+                    if (value < h)
+                        h = value;
+                }
+
+    /* add h to each covered row */
+    for (row = 0; row < nOfRows; row++)
+        if (coveredRows[row])
+            for (col = 0; col < nOfColumns; col++)
+                distMatrix[row + nOfRows * col] += h;
+
+    /* subtract h from each uncovered column */
+    for (col = 0; col < nOfColumns; col++)
+        if (!coveredColumns[col])
+            for (row = 0; row < nOfRows; row++)
+                distMatrix[row + nOfRows * col] -= h;
+
+    /* move to step 3 */
+    Hungarian::step3(assignment, distMatrix, starMatrix, newStarMatrix, primeMatrix, coveredColumns, coveredRows, nOfRows, nOfColumns, minDim);
+}
+
+bool Hungarian::isLink()
+{
+    std::cout << "Hungarian.cpp とのリンク成功" << std::endl;
+    return true;
+}

--- a/Experiment/600x600/Tracker/Tracker.hpp
+++ b/Experiment/600x600/Tracker/Tracker.hpp
@@ -1,0 +1,71 @@
+// ----------------------------------------------------------------
+// tracker.hpp
+//
+// ユーザの足位置を追跡するためのクラスと関数の宣言
+//
+// Copyright (c) 2026 Maito Yasui
+// Released under the GNU GPL-3.0 License.
+// https://github.com/Nibosi0501/LiViMotion/blob/main/LICENSE
+// ----------------------------------------------------------------
+
+#pragma once
+#include "../Yolo/Yolo.hpp"
+#include "../Lidar/Lidar.hpp"
+
+#include "../Kalman/Kalman.hpp"
+
+#include <chrono>
+
+namespace tkr
+{
+    constexpr int MAX_HISTORY_SIZE = 5;
+    constexpr int MAX_SKIPPED_FRAMES = 30;
+    constexpr double EUCLIDEAN_LIDAR_THRESHOLD = 130.0;
+    constexpr double EUCLIDEAN_YOLO_THRESHOLD = 130.0;
+    constexpr double SQUARED_EUCLIDEAN_LIDAR_THRESHOLD = EUCLIDEAN_LIDAR_THRESHOLD * EUCLIDEAN_LIDAR_THRESHOLD;
+    constexpr double SQUARED_EUCLIDEAN_YOLO_THRESHOLD = EUCLIDEAN_YOLO_THRESHOLD * EUCLIDEAN_YOLO_THRESHOLD;
+
+    struct IDGenerator
+    {
+        int nextID = 0;
+        int generate()
+        {
+            int id = nextID++;
+            if (nextID > 10000)
+                nextID = 0;
+            return id;
+        }
+    };
+
+    struct LidarTracker
+    {
+        int id;
+        int skippedFrames;
+        lidar::Lidar currentLidar;
+        std::deque<lidar::Lidar> historys;
+
+        // std::chrono::steady_clock::time_point lastAddHistoryTime;
+
+        LidarTracker(IDGenerator &idGen, const lidar::Lidar &_currentLidar, const int &_skippedFrames = 0, const std::deque<lidar::Lidar> &historys = std::deque<lidar::Lidar>());
+        void addHistory(const lidar::Lidar &lidar);
+    };
+
+    void updateTrackers(std::vector<tkr::LidarTracker> &lidarTrackers, const std::vector<lidar::Lidar> &currentLidars, IDGenerator &idGen);
+    void deleteLostTrackers(std::vector<tkr::LidarTracker> &lidarTrackers);
+
+    struct YoloTracker
+    {
+        int id;
+        int skippedFrames;
+        yolo::Yolo currentYolo;
+        std::deque<yolo::Yolo> historys;
+
+        kf::KalmanYolo kalmanYolo;
+
+        YoloTracker(IDGenerator &idGen, const yolo::Yolo &_currentYolo, const int &_skippedFrames = 0, const std::deque<yolo::Yolo> &_historys = std::deque<yolo::Yolo>());
+        void addHistory(const yolo::Yolo &yolo);
+    };
+
+    void updateTrackers(std::vector<tkr::YoloTracker> &yoloTrackers, const std::vector<yolo::Yolo> &currentYolos, IDGenerator &idGen);
+    void deleteLostTrackers(std::vector<tkr::YoloTracker> &yoloTrackers);
+}

--- a/Experiment/600x600/Tracker/tracker.cpp
+++ b/Experiment/600x600/Tracker/tracker.cpp
@@ -1,0 +1,199 @@
+// ----------------------------------------------------------------
+// tracker.cpp
+//
+// ユーザの足位置を追跡するためのクラスと関数の実装
+//
+// Copyright (c) 2026 Maito Yasui
+// Released under the GNU GPL-3.0 License.
+// https://github.com/Nibosi0501/LiViMotion/blob/main/LICENSE
+// ----------------------------------------------------------------
+
+#include "./Tracker.hpp"
+#include "./Hungarian/Hungarian.hpp"
+
+namespace tkr
+{
+    LidarTracker::LidarTracker(IDGenerator &idGen, const lidar::Lidar &_currentLidar, const int &_skippedFrames, const std::deque<lidar::Lidar> &historys)
+        : currentLidar(_currentLidar), skippedFrames(_skippedFrames), historys(historys)
+    {
+        id = idGen.generate();
+        // lastAddHistoryTime = std::chrono::steady_clock::now();
+    }
+
+    void LidarTracker::addHistory(const lidar::Lidar &lidar)
+    {
+        if (historys.size() >= MAX_HISTORY_SIZE)
+        {
+            historys.pop_front();
+        }
+
+        historys.emplace_back(lidar);
+    }
+
+    void updateTrackers(std::vector<tkr::LidarTracker> &lidarTrackers, const std::vector<lidar::Lidar> &currentLidars, IDGenerator &idGen)
+    {
+        if (currentLidars.empty())
+        {
+            for (auto &tracker : lidarTrackers)
+            {
+                tracker.skippedFrames++;
+            }
+            return;
+        }
+
+        if (lidarTrackers.empty())
+        {
+            lidarTrackers.reserve(currentLidars.size());
+            for (const auto &lidar : currentLidars)
+            {
+                lidarTrackers.emplace_back(idGen, lidar);
+                lidarTrackers.back().addHistory(lidar);
+            }
+            return;
+        }
+
+        int nTracks = lidarTrackers.size();
+        int nLidars = currentLidars.size();
+        std::vector<std::vector<double>> costMatrix(nTracks, std::vector<double>(nLidars));
+        for (int row = 0; row < nTracks; row++)
+        {
+            for (int col = 0; col < nLidars; col++)
+            {
+                costMatrix.at(row).at(col) = static_cast<double>(std::pow(lidarTrackers.at(row).currentLidar.footX - currentLidars.at(col).footX, 2) +
+                                                                 std::pow(lidarTrackers.at(row).currentLidar.footY - currentLidars.at(col).footY, 2));
+            }
+        }
+
+        std::vector<int> assignment;
+        Hungarian::Solve(costMatrix, assignment);
+
+        std::vector<bool> lidar_used(nLidars, false);
+        for (int row = 0; row < nTracks; row++)
+        {
+            int col = assignment.at(row);
+            if (col >= 0 && costMatrix.at(row).at(col) < SQUARED_EUCLIDEAN_LIDAR_THRESHOLD)
+            {
+                // 最新のLidar履歴点と今の観測点が２乗距離で閾値以上離れているならば、その点を履歴に追加する
+                double dist = std::pow(lidarTrackers.at(row).historys.back().footX - currentLidars.at(col).footX, 2) +
+                              std::pow(lidarTrackers.at(row).historys.back().footY - currentLidars.at(col).footY, 2);
+                if (dist >= 2500.0f)
+                {
+                    lidarTrackers.at(row).addHistory(currentLidars.at(col));
+                }
+
+                lidarTrackers.at(row).currentLidar = currentLidars.at(col);
+                lidarTrackers.at(row).skippedFrames = 0;
+                lidar_used.at(col) = true;
+            }
+            else
+            {
+                lidarTrackers.at(row).skippedFrames++;
+            }
+        }
+
+        for (int col = 0; col < nLidars; col++)
+        {
+            if (lidar_used.at(col) == false)
+            {
+                lidarTrackers.emplace_back(idGen, currentLidars.at(col));
+                lidarTrackers.back().addHistory(currentLidars.at(col));
+            }
+        }
+    }
+
+    void deleteLostTrackers(std::vector<tkr::LidarTracker> &lidarTrackers)
+    {
+        std::erase_if(lidarTrackers, [](auto &tracker)
+                      { return tracker.skippedFrames > MAX_SKIPPED_FRAMES; });
+    }
+
+    YoloTracker::YoloTracker(IDGenerator &idGen, const yolo::Yolo &_currentYolo, const int &_skippedFrames, const std::deque<yolo::Yolo> &_historys)
+        : currentYolo(_currentYolo), skippedFrames(_skippedFrames), historys(_historys), kalmanYolo(_currentYolo)
+    {
+        id = idGen.generate();
+    }
+
+    void YoloTracker::addHistory(const yolo::Yolo &yolo)
+    {
+        if (historys.size() >= MAX_HISTORY_SIZE)
+        {
+            historys.pop_front();
+        }
+
+        historys.emplace_back(yolo);
+    }
+
+    void updateTrackers(std::vector<tkr::YoloTracker> &yoloTrackers, const std::vector<yolo::Yolo> &currentYolos, IDGenerator &idGen)
+    {
+        if (currentYolos.empty())
+        {
+            for (auto &tracker : yoloTrackers)
+            {
+                tracker.skippedFrames++;
+                tracker.kalmanYolo.predict(); // 観測なしでも予測ステップを実行
+            }
+            return;
+        }
+
+        if (yoloTrackers.empty())
+        {
+            yoloTrackers.reserve(currentYolos.size());
+            for (const auto &yolo : currentYolos)
+            {
+                yoloTrackers.emplace_back(idGen, yolo);
+            }
+            return;
+        }
+
+        int nTracks = yoloTrackers.size();
+        int nYolos = currentYolos.size();
+        std::vector<std::vector<double>> costMatrix(nTracks, std::vector<double>(nYolos));
+        for (int row = 0; row < nTracks; row++)
+        {
+            for (int col = 0; col < nYolos; col++)
+            {
+                costMatrix.at(row).at(col) = static_cast<double>(std::pow(yoloTrackers.at(row).currentYolo.footX - currentYolos.at(col).footX, 2) +
+                                                                 std::pow(yoloTrackers.at(row).currentYolo.footY - currentYolos.at(col).footY, 2));
+            }
+        }
+
+        std::vector<int> assignment;
+        Hungarian::Solve(costMatrix, assignment);
+
+        std::vector<bool> yolo_used(nYolos, false);
+        for (int row = 0; row < nTracks; row++)
+        {
+            int col = assignment.at(row);
+            if (col >= 0 && costMatrix.at(row).at(col) < SQUARED_EUCLIDEAN_YOLO_THRESHOLD)
+            {
+                yoloTrackers.at(row).addHistory(yoloTrackers.at(row).currentYolo);
+
+                yoloTrackers.at(row).currentYolo = currentYolos.at(col);
+                yoloTrackers.at(row).skippedFrames = 0;
+                yolo_used.at(col) = true;
+
+                // Kalman Filter
+                yoloTrackers.at(row).kalmanYolo.update(currentYolos.at(col));
+            }
+            else
+            {
+                yoloTrackers.at(row).skippedFrames++;
+                yoloTrackers.at(row).kalmanYolo.predict(); // 観測なしでも予測ステップを実行
+            }
+        }
+
+        for (int col = 0; col < nYolos; col++)
+        {
+            if (yolo_used.at(col) == false)
+            {
+                yoloTrackers.emplace_back(idGen, currentYolos.at(col));
+            }
+        }
+    }
+
+    void deleteLostTrackers(std::vector<tkr::YoloTracker> &yoloTrackers)
+    {
+        std::erase_if(yoloTrackers, [](auto &tracker)
+                      { return tracker.skippedFrames > MAX_SKIPPED_FRAMES || tracker.currentYolo.footConf < 0; });
+    }
+}


### PR DESCRIPTION
## 概要
LiDAR・YOLO の足位置をフレーム間で同一人物に紐付けるトラッカークラスと、割り当て問題を解くハンガリアンアルゴリズムを新規追加した。

## 追加内容

### トラッカー (`Tracker.hpp` / `tracker.cpp`)
- `tkr::LidarTracker` / `tkr::YoloTracker` : 足位置・履歴・スキップフレーム数を管理するトラッカー構造体
- `updateTrackers()` : ハンガリアンマッチングで観測点とトラッカーを対応付けし更新 (LiDAR / YOLO オーバーロード)
- `deleteLostTrackers()` : 一定フレーム以上観測されなかったトラッカーを削除

| クラス / 関数 | 役割 |
|---|---|
| `tkr::IDGenerator` | 0〜10000 の循環 ID を発行 |
| `tkr::LidarTracker` | LiDAR 点の追跡。足位置履歴 (最大5件) を保持 |
| `tkr::YoloTracker` | YOLO 点の追跡。カルマンフィルタ (`KalmanYolo`) を内包 |
| `updateTrackers()` | ハンガリアンマッチングで観測点とトラッカーを対応付けし更新 (LiDAR / YOLO のオーバーロード) |
| `deleteLostTrackers()` | `skippedFrames > 30` のトラッカーを削除 |
| `Hungarian::Solve()` | ムンクレスアルゴリズムで最小コスト割り当てを計算 |

### ハンガリアンアルゴリズム (`Hungarian.hpp` / `hungarian.cpp`)
- Markus Buehren / Cong Ma の実装をベースに改変
- `Hungarian::Solve()` : コスト行列から最小コスト割り当てを計算して返す

## マッチング仕様
- コストは足位置の**ユークリッド距離の2乗**
- 閾値: LiDAR / YOLO ともに 130² = 16900
- 閾値を超えるペアは新規トラッカーとして生成
- YOLO は観測欠落フレームでもカルマンフィルタの `predict()` を実行